### PR TITLE
Add --export/--write flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 ## Motivation
 
-AWS CLI supports role assumption by [caching temporary credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html), but unfortunately does not place the temporary session credentials in a location where many other tools are expecting them to be.
+AWS CLI supports role assumption by [caching temporary credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html), but unfortunately does not export the temporary credentials to locations where other external applications are expecting them.
 
-`aws-role-play` makes it easier to switch between different roles. Assuming privileged roles with temporary credentials is good practice. Assuming roles eliminates the need to store privileged access keys for extended periods of time. This tool re-uses the same credentials cache as AWS CLI, puts the credentials in `~/.aws/credentials` so that external applications can read the credentials.
+`aws-role-play` makes it easier to write and export these temporary credentials. Assuming roles eliminates the need to store and transmit privileged long-term access keys. This tool re-uses the same credentials cache as AWS CLI, and then either exports the credentials to the current shell, or puts the credentials in `~/.aws/credentials` (or `AWS_SHARED_CREDENTIALS_FILE`) so that external applications can read the credentials.
 
 For more information on current issues:
 
+- https://github.com/hashicorp/terraform-provider-aws/issues/10491
 - https://github.com/aws/aws-cli/issues/4676
-- https://github.com/hashicorp/terraform-provider-aws/issues/10110
-
-If you have used [aws-extend-switch-roles](https://github.com/tilfinltd/aws-extend-switch-roles) in a web browser, this aims to be as convenient for terminal usage (i.e [terraform](https://github.com/hashicorp/terraform), [aws-nuke](https://github.com/rebuy-de/aws-nuke), etc).
 
 ## Installation
 
@@ -46,7 +44,17 @@ Having a `mfa_serial` is optional, but it's highly recommended that a policy req
 
 ## Usage
 
-> Note: Temporary role credentials are stored (and will overwrite existing credentials) in the profile provided
+## Exporting
+
+To export the temporary credentials to the current shell:
+
+```sh
+eval $(aws-role-play assume --profile personal-admin --export)
+```
+
+## Writing
+
+> Note: Temporary credentials will overwrite any existing credentials in the profile provided
 
 ```sh
 Usage: aws-role-play [OPTIONS] COMMAND [ARGS]...
@@ -62,10 +70,10 @@ Commands:
   list    List all roles defined in the aws config
 ```
 
-Based on the above configuration, to assume the admin role:
+Based on the above configuration, to assume the admin role and update your credentials:
 
 ```sh
-aws-role-play assume --profile personal-admin
+aws-role-play assume --profile personal-admin --write
 ```
 
 After assuming a role, check your identity by:
@@ -74,12 +82,12 @@ After assuming a role, check your identity by:
 aws sts get-caller-identity --profile personal-admin
 ```
 
-## TODO
-
-- When a profile is not specified with assume, a selection list should be presented
-
 ## Additional Resources
 
-- If your organization has [SSO](https://aws.amazon.com/single-sign-on/), you should consider [integrating it with awscli](https://docs.aws.amazon.com/singlesignon/latest/userguide/integrating-aws-cli.html) for an easier way to switch between roles and accounts. There is also [aws2-wrap](https://github.com/linaro-its/aws2-wrap) to get around the current limitations of awscli v2.
+- If your organization has [SSO](https://aws.amazon.com/single-sign-on/), you should consider [integrating it with awscli](https://docs.aws.amazon.com/singlesignon/latest/userguide/integrating-aws-cli.html) for an easier way to switch between roles and accounts. It doesn't export credentials either, so something like [aws2-wrap](https://github.com/linaro-its/aws2-wrap) helps.
+
+- [aws-vault](https://github.com/99designs/aws-vault) provides a secure way to store and access credentials.
 
 - If you use Azure AD, you might want to consider [aws-azure-login](https://github.com/sportradar/aws-azure-login).
+
+- [aws-extend-switch-roles](https://github.com/tilfinltd/aws-extend-switch-roles) is a set of browser extensions for switching roles based on aws config.

--- a/aws_role_play/__init__.py
+++ b/aws_role_play/__init__.py
@@ -1,5 +1,10 @@
 import os
 from os.path import expanduser
 
-AWS_CREDENTIALS_PATH = os.path.join(expanduser("~"), ".aws/credentials")
-AWS_CONFIG_PATH = os.path.join(expanduser("~"), ".aws/config")
+AWS_CONFIG_FILE = os.getenv(
+    "AWS_CONFIG_FILE", os.path.join(expanduser("~"), ".aws/config")
+)
+AWS_SHARED_CREDENTIALS_FILE = os.getenv(
+    "AWS_SHARED_CREDENTIALS_FILE", os.path.join(expanduser("~"), ".aws/credentials")
+)
+AWS_PROFILE = os.getenv("AWS_PROFILE")

--- a/aws_role_play/cli.py
+++ b/aws_role_play/cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import uuid
 import os
 from importlib.metadata import version
 
@@ -108,7 +107,7 @@ def assume(profile, write, export, aws_cache_dir):
         write_session_credentials(updated_config, AWS_SHARED_CREDENTIALS_FILE)
 
     if export:
-        export_session_credentials(session_credentials, config, profile)
+        export_session_credentials(session_credentials)
 
 
 @cli.command(short_help="List all roles defined in the aws config")

--- a/aws_role_play/cli.py
+++ b/aws_role_play/cli.py
@@ -9,9 +9,13 @@ import click
 from botocore import credentials
 from botocore.session import Session
 
-from . import AWS_CONFIG_PATH, AWS_CREDENTIALS_PATH
+from . import AWS_CONFIG_FILE, AWS_SHARED_CREDENTIALS_FILE, AWS_PROFILE
 from .config import load_config
-from .sts import update_session_credentials, write_session_credentials
+from .sts import (
+    export_session_credentials,
+    update_session_credentials,
+    write_session_credentials,
+)
 from .roles import get_list_of_roles
 
 
@@ -45,39 +49,71 @@ def cli(ctx):
 @cli.command(short_help="Assumes a role and updates session credentials")
 @click.option(
     "--profile",
-    prompt="AWS Profile",
-    help="The profile you wish to assume (it must have a role_arn defined).",
+    help="The profile you wish to assume (it must have a role_arn defined)",
 )
-def assume(profile):
-    credentials_config = load_config(AWS_CREDENTIALS_PATH)
-    config = load_config(AWS_CONFIG_PATH)
+@click.option(
+    "--write",
+    default=False,
+    is_flag=True,
+    help="Whether or not to write credentials to the profile in AWS_CONFIG_FILE",
+)
+@click.option(
+    "--export",
+    default=False,
+    is_flag=True,
+    help="Whether or not to export the temporary security credentials as environment variables",
+)
+@click.option(
+    "--aws-cache-dir",
+    default=None,
+    help="The cache directory that awscli uses for either cli or sso. Defaults to ~/.aws/cli/cache",
+)
+def assume(profile, write, export, aws_cache_dir):
+
+    if write is False and export is False:
+        exit("Must choose to --export and/or --write")
+
+    if profile is None:
+        if AWS_PROFILE is None:
+            profile = click.prompt("AWS Profile")
+        else:
+            profile = AWS_PROFILE
+
+    credentials_config = load_config(AWS_SHARED_CREDENTIALS_FILE)
+    config = load_config(AWS_CONFIG_FILE)
 
     source_profile = config[f"profile {profile}"].get("source_profile")
 
     # Re-use the same cache as awscli
-    working_dir = os.path.join(os.path.expanduser("~"), ".aws/cli/cache")
+    if aws_cache_dir is None:
+        aws_cache_dir = os.path.join(os.path.expanduser("~"), ".aws/cli/cache")
 
     # Construct botocore session with cache
     cached_session = Session(profile=profile)
     provider = cached_session.get_component("credential_provider").get_provider(
         "assume-role"
     )
-    provider.cache = credentials.JSONFileCache(working_dir)
+    provider.cache = credentials.JSONFileCache(aws_cache_dir)
 
     # Authenticate using the source profile
     session = boto3.session.Session(
         profile_name=source_profile, botocore_session=cached_session
     )
     session_credentials = session.get_credentials().get_frozen_credentials()
-    updated_config = update_session_credentials(
-        credentials_config, session_credentials, profile
-    )
-    write_session_credentials(updated_config, AWS_CREDENTIALS_PATH)
+
+    if write:
+        updated_config = update_session_credentials(
+            credentials_config, session_credentials, profile
+        )
+        write_session_credentials(updated_config, AWS_SHARED_CREDENTIALS_FILE)
+
+    if export:
+        export_session_credentials(session_credentials, config, profile)
 
 
 @cli.command(short_help="List all roles defined in the aws config")
 def list():
-    config = load_config(AWS_CONFIG_PATH)
+    config = load_config(AWS_CONFIG_FILE)
     roles = get_list_of_roles(config)
     for role, profile in roles:
         print(f"{role} ({profile})")

--- a/aws_role_play/sts.py
+++ b/aws_role_play/sts.py
@@ -1,3 +1,6 @@
+import os
+
+
 def update_session_credentials(config, session_credentials, profile):
 
     if not config.has_section(profile):
@@ -14,3 +17,9 @@ def write_session_credentials(config, credentials_path):
 
     with open(credentials_path, "w") as configfile:
         config.write(configfile)
+
+
+def export_session_credentials(session_credentials, config, profile):
+    print(f"export AWS_ACCESS_KEY_ID={session_credentials.access_key}")
+    print(f"export AWS_SECRET_ACCESS_KEY={session_credentials.secret_key}")
+    print(f"export AWS_SESSION_TOKEN={session_credentials.token}")

--- a/aws_role_play/sts.py
+++ b/aws_role_play/sts.py
@@ -1,6 +1,3 @@
-import os
-
-
 def update_session_credentials(config, session_credentials, profile):
 
     if not config.has_section(profile):
@@ -19,7 +16,7 @@ def write_session_credentials(config, credentials_path):
         config.write(configfile)
 
 
-def export_session_credentials(session_credentials, config, profile):
+def export_session_credentials(session_credentials):
     print(f"export AWS_ACCESS_KEY_ID={session_credentials.access_key}")
     print(f"export AWS_SECRET_ACCESS_KEY={session_credentials.secret_key}")
     print(f"export AWS_SESSION_TOKEN={session_credentials.token}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-role-play"
-version = "0.1.0"
+version = "0.2.0"
 description = "A CLI tool that makes assuming IAM roles easier"
 authors = ["Dave Gallant <dave.gallant@rewind.io>"]
 license = "MIT"

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -26,13 +26,11 @@ def aws_config(role_admin, role_readonly):
     return config
 
 
-def test_get_list_of_roles(
-    aws_config,
-):
+def test_get_list_of_roles(aws_config, role_admin, role_readonly):
 
     roles = get_list_of_roles(aws_config)
 
     assert roles == [
-        ("arn:aws:iam::555555555555:role/admin", "admin"),
-        ("arn:aws:iam::555555555555:role/read-only", "readonly"),
+        (role_admin, "admin"),
+        (role_readonly, "readonly"),
     ]


### PR DESCRIPTION
###### Motivation for this change

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

* Add required flags --export (export env vars) and/or --write (write credentials to disk)
* Update README
* Allow environment variable overrides of `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` as awscli species in its [docs](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html)

###### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

###### Tests

<!--
Please describe the tests that you ran to verify your changes.
-->
